### PR TITLE
Clean Up & split Node and logic

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,11 +1,11 @@
 ---
 Checks: '-*,
-        clang-analyzer-*,
+        clang-analyzer-*,-clang-diagnostic-error,
         google-*,
         llvm-*,-llvm-header-guard,
-        readability-*'
+        readability-*,-readability-convert-member-functions-to-static,-readability-make-member-function-const'
 WarningsAsErrors: ''
-HeaderFilterRegex: ''
+HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,19 +47,54 @@ install(TARGETS
 
 target_compile_options(${PROJECT_NAME} PUBLIC -Wall -Wextra -Wpedantic -Werror)
 
-ament_target_dependencies(${PROJECT_NAME} rclcpp Boost "sonia_common_cpp" sonia_common_ros2 std_msgs std_srvs)
+set(DEPS rclcpp Boost sonia_common_cpp sonia_common_ros2 std_msgs std_srvs)
 
+ament_target_dependencies(${PROJECT_NAME} ${DEPS})
 
 if(BUILD_TESTING)
+  list(REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
+  add_library(
+    ${PROJECT_NAME}_lib SHARED
+    ${SOURCES}
+  )
+  target_include_directories(
+    ${PROJECT_NAME}_lib PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}_lib>
+    $<INSTALL_INTERFACE:include>
+  )
+  install(
+    TARGETS ${PROJECT_NAME}_lib
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+  )
+
+  ament_export_include_directories(include)
+  ament_export_libraries(${PROJECT_NAME}_lib)
+  ament_target_dependencies(${PROJECT_NAME}_lib ${DEPS})# linking the dependencies to executables
+
   find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
   # the following line skips the linter which checks for copyrights
   # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
+  # set(ament_cmake_copyright_FOUND TRUE)
   # the following line skips cpplint (only works in a git repo)
   # comment the line when this package is in a git repo and when
   # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
+  # set(ament_cmake_cpplint_FOUND TRUE)
+  file(GLOB TEST_SOURCES test/*.cpp)
+  ament_add_gtest(${PROJECT_NAME}_test ${TEST_SOURCES})
+  target_include_directories(${PROJECT_NAME}_test PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  ament_target_dependencies(${PROJECT_NAME}_test
+    ${DEPS}
+  )
+  target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME}_lib)# permet de relier la librairie qui est en fait le ArmProvider.cpp sans le main (pour NE PAS avoir multiples main, le main du fichier test et le main des fichiers src)
+
+  # ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(depth_port_manager)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -6,16 +6,20 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
+# ROS Dependencies =========================================================
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.c
-# find_package(<dependency> REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sonia_common_cpp REQUIRED)
 find_package(sonia_common_ros2 REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(std_msgs REQUIRED)
+
+# Other Dependencies =======================================================
+
 find_package(Boost COMPONENTS log REQUIRED)
+
+# ==========================================================================
+
 include_directories(include)
 
 file(GLOB SOURCES src/*.cpp)
@@ -28,18 +32,23 @@ install(
 )
 install(
   DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}/
+  DESTINATION share/${PROJECT_NAME}
 )
 
 install(
   DIRECTORY config
-  DESTINATION share/${PROJECT_NAME}/
+  DESTINATION share/${PROJECT_NAME}
 )
-install(TARGETS
-${PROJECT_NAME}
-  DESTINATION lib/${PROJECT_NAME})
 
-ament_target_dependencies(${PROJECT_NAME} rclcpp Boost sonia_common_cpp sonia_common_ros2 std_msgs std_srvs)
+install(TARGETS
+  ${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+target_compile_options(${PROJECT_NAME} PUBLIC -Wall -Wextra -Wpedantic -Werror)
+
+ament_target_dependencies(${PROJECT_NAME} rclcpp Boost "sonia_common_cpp" sonia_common_ros2 std_msgs std_srvs)
+
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/include/depth_port_manager/DepthProvider.hpp
+++ b/include/depth_port_manager/DepthProvider.hpp
@@ -1,51 +1,54 @@
 #pragma once
 
-#include <std_msgs/msg/float32.hpp>
-#include <std_srvs/srv/trigger.hpp>
+#include <stdio.h>
+
 #include <sonia_common_cpp/SerialConn.hpp>
 #include <sonia_common_cpp/SharedQueue.hpp>
-
-#include <stdio.h>
+#include <std_msgs/msg/float32.hpp>
+#include <std_srvs/srv/trigger.hpp>
 #include <string>
 #include <thread>
+
 #include "rclcpp/rclcpp.hpp"
 
 #define ID1 "ISDPT"
 
-namespace depth_provider
+namespace depth_port_manager
 {
-    class DepthProvider:public rclcpp::Node
+    class DepthProvider : public rclcpp::Node
     {
         public:
-            DepthProvider();
-            ~DepthProvider();
-            bool OpenPort();
-        private:  
+        DepthProvider();
+        ~DepthProvider();
+        bool OpenPort();
+
+        private:
+        void readSerialDevice();
+        void sendId1Register();
+        void tare(std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                  std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+        sonia_common_cpp::SharedQueue<std::string> _id1String;
+
+        bool _readStopThread = false;
+        std::thread _readThread;
+
+        bool _sendStopThread = false;
+        std::thread _sendThread;
+
         
-            sonia_common_cpp::SharedQueue<std::string> id1_string;
-            
-            bool _read_stop_thread=false;
-            std::thread read_thread;
-
-            bool _send_stop_thread=false;
-            std::thread send_thread;
-
-            void readSerialDevice();
-            void sendId1Register();
-
-            static const int BUFFER_SIZE= 4096;
-
-            sonia_common_cpp::SerialConn _serialConnection;
-
-            rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr depthPublisher_;
-            rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pressPublisher_;
-            rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr tempPublisher_;
-
-            std_msgs::msg::Float32 depth_;
-            std_msgs::msg::Float32 press_;
-            std_msgs::msg::Float32 temp_;
-
-            void tare(const std::shared_ptr<std_srvs::srv::Trigger::Request> request, std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-            rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr tare_srv;
+        sonia_common_cpp::SerialConn _serialConnection;
+        
+        rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr _depthPublisher;
+        rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr _pressPublisher;
+        rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr _tempPublisher;
+        
+        std_msgs::msg::Float32 _depth;
+        std_msgs::msg::Float32 _press;
+        std_msgs::msg::Float32 _temp;
+        
+        
+        rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr _tareSrv;
+        static const int BUFFER_SIZE = 4096;
+        static const int ID_SIZE = 5;
     };
-}
+}  // namespace depth_port_manager

--- a/include/depth_port_manager/DepthProvider.hpp
+++ b/include/depth_port_manager/DepthProvider.hpp
@@ -9,8 +9,8 @@
 #include <string>
 #include <thread>
 
-#include "rclcpp/rclcpp.hpp"
 #include "depth_port_manager/IDepthDevice.hpp"
+#include "rclcpp/rclcpp.hpp"
 namespace depth_port_manager
 {
     class DepthProvider : public rclcpp::Node
@@ -18,7 +18,6 @@ namespace depth_port_manager
         public:
         DepthProvider(IDepthDevice& device, sonia_common_cpp::SerialConn& conn);
         ~DepthProvider();
-        bool OpenPort();
 
         private:
         void readSerialDevice();
@@ -36,18 +35,13 @@ namespace depth_port_manager
         bool _sendStopThread = false;
         std::thread _sendThread;
 
-        
+
         sonia_common_cpp::SerialConn& _connection;
-        
+
         rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr _depthPublisher;
         rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr _pressPublisher;
         rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr _tempPublisher;
-        
-        std_msgs::msg::Float32 _depth;
-        std_msgs::msg::Float32 _press;
-        std_msgs::msg::Float32 _temp;
-        
-        
+
         rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr _tareSrv;
         static const int BUFFER_SIZE = 4096;
         static const int ID_SIZE = 5;

--- a/include/depth_port_manager/DepthProvider.hpp
+++ b/include/depth_port_manager/DepthProvider.hpp
@@ -10,15 +10,13 @@
 #include <thread>
 
 #include "rclcpp/rclcpp.hpp"
-
-#define ID1 "ISDPT"
-
+#include "depth_port_manager/IDepthDevice.hpp"
 namespace depth_port_manager
 {
     class DepthProvider : public rclcpp::Node
     {
         public:
-        DepthProvider();
+        DepthProvider(IDepthDevice& device, sonia_common_cpp::SerialConn& conn);
         ~DepthProvider();
         bool OpenPort();
 
@@ -27,6 +25,9 @@ namespace depth_port_manager
         void sendId1Register();
         void tare(std::shared_ptr<std_srvs::srv::Trigger::Request> request,
                   std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+
+        IDepthDevice& _device;
+
         sonia_common_cpp::SharedQueue<std::string> _id1String;
 
         bool _readStopThread = false;
@@ -36,7 +37,7 @@ namespace depth_port_manager
         std::thread _sendThread;
 
         
-        sonia_common_cpp::SerialConn _serialConnection;
+        sonia_common_cpp::SerialConn& _connection;
         
         rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr _depthPublisher;
         rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr _pressPublisher;

--- a/include/depth_port_manager/IDepthDevice.hpp
+++ b/include/depth_port_manager/IDepthDevice.hpp
@@ -13,12 +13,15 @@ namespace depth_port_manager
         float depth;
         float temp;
         float press;
+        bool operator==(const DepthData& other) const {
+            return depth == other.depth && temp == other.temp && press == other.press;
+        }
     };
 
     class IDepthDevice
     {
         public:
-        virtual bool ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize) = 0;
+        virtual int ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize) = 0;
         virtual DepthData ParseData(std::string data) = 0;
         virtual void Tare(std::function<ssize_t(std::string)> writeFunc) = 0;
     };

--- a/include/depth_port_manager/IDepthDevice.hpp
+++ b/include/depth_port_manager/IDepthDevice.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdio.h>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace depth_port_manager
+{
+
+    struct DepthData {
+        float depth;
+        float temp;
+        float press;
+    };
+
+    class IDepthDevice
+    {
+        public:
+        virtual bool ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize) = 0;
+        virtual DepthData ParseData(std::string data) = 0;
+        virtual void Tare(std::function<ssize_t(std::string)> writeFunc) = 0;
+    };
+}  // namespace depth_port_manager

--- a/include/depth_port_manager/IDepthDevice.hpp
+++ b/include/depth_port_manager/IDepthDevice.hpp
@@ -9,11 +9,13 @@
 namespace depth_port_manager
 {
 
-    struct DepthData {
+    struct DepthData
+    {
         float depth;
         float temp;
         float press;
-        bool operator==(const DepthData& other) const {
+        bool operator==(const DepthData& other) const
+        {
             return depth == other.depth && temp == other.temp && press == other.press;
         }
     };
@@ -21,7 +23,7 @@ namespace depth_port_manager
     class IDepthDevice
     {
         public:
-        virtual int ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize) = 0;
+        virtual int ReadDataCheck(std::function<ssize_t(uint8_t*, int)> readFunc, char buffer[], int bufferSize) = 0;
         virtual DepthData ParseData(std::string data) = 0;
         virtual void Tare(std::function<ssize_t(std::string)> writeFunc) = 0;
     };

--- a/include/depth_port_manager/ImpactSubsea.hpp
+++ b/include/depth_port_manager/ImpactSubsea.hpp
@@ -8,10 +8,9 @@ namespace depth_port_manager
         public:
         ImpactSubsea()=default;
         ~ImpactSubsea()=default;
-        bool ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize) override;
+        int ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize) override;
         DepthData ParseData(std::string data) override;
         void Tare(std::function<ssize_t(std::string)> writeFunc) override;
-        private:
         static const int ID_SIZE = 5;
         static const std::string ID1;
     };

--- a/include/depth_port_manager/ImpactSubsea.hpp
+++ b/include/depth_port_manager/ImpactSubsea.hpp
@@ -1,17 +1,18 @@
 #pragma once
-#include "depth_port_manager/IDepthDevice.hpp"
-
 #include <string>
+
+#include "depth_port_manager/IDepthDevice.hpp"
 namespace depth_port_manager
 {
-    class ImpactSubsea : public IDepthDevice {
+    class ImpactSubsea : public IDepthDevice
+    {
         public:
-        ImpactSubsea()=default;
-        ~ImpactSubsea()=default;
+        ImpactSubsea() = default;
+        ~ImpactSubsea() = default;
         int ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize) override;
         DepthData ParseData(std::string data) override;
         void Tare(std::function<ssize_t(std::string)> writeFunc) override;
         static const int ID_SIZE = 5;
         static const std::string ID1;
     };
-} // namespace depth_port_manager
+}  // namespace depth_port_manager

--- a/include/depth_port_manager/ImpactSubsea.hpp
+++ b/include/depth_port_manager/ImpactSubsea.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "depth_port_manager/IDepthDevice.hpp"
+
+#include <string>
+namespace depth_port_manager
+{
+    class ImpactSubsea : public IDepthDevice {
+        public:
+        ImpactSubsea()=default;
+        ~ImpactSubsea()=default;
+        bool ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize) override;
+        DepthData ParseData(std::string data) override;
+        void Tare(std::function<ssize_t(std::string)> writeFunc) override;
+        private:
+        static const int ID_SIZE = 5;
+        static const std::string ID1;
+    };
+} // namespace depth_port_manager

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-
+  <test_depend>ament_cmake_gtest</test_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depth_port_manager</name>
-  <version>0.0.0</version>
+  <version>0.0.1</version>
   <description>TODO: Package description</description>
   <maintainer email="log.club.sonia@etsmtl.net">Sonia LOG Team</maintainer>
   <license>TODO: License declaration</license>

--- a/src/DepthProvider.cpp
+++ b/src/DepthProvider.cpp
@@ -1,35 +1,36 @@
-#include <sstream>
-#include "boost/log/trivial.hpp"
+// #include <sstream>
 #include "depth_port_manager/DepthProvider.hpp"
+
+#include <boost/log/trivial.hpp>
 
 using std::placeholders::_1;
 using std::placeholders::_2;
 using namespace std::chrono_literals;
 
-namespace depth_provider
+namespace depth_port_manager
 {
-    DepthProvider::DepthProvider()
-        : Node("depth_provider"), _serialConnection("/dev/DEPTH", B115200, true)
+    DepthProvider::DepthProvider() : Node("depth_provider"), _serialConnection("/dev/DEPTH", B115200, true)
     {
-        depthPublisher_ = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/depth", 100);
-        pressPublisher_ = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/press", 100);
-        tempPublisher_ = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/temp", 100);
+        _depthPublisher = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/depth", 100);
+        _pressPublisher = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/press", 100);
+        _tempPublisher = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/temp", 100);
 
-        read_thread = std::thread(std::bind(&DepthProvider::readSerialDevice, this));
-        send_thread = std::thread(std::bind(&DepthProvider::sendId1Register, this));
+        _readThread = std::thread(std::bind(&DepthProvider::readSerialDevice, this));
+        _sendThread = std::thread(std::bind(&DepthProvider::sendId1Register, this));
 
-        tare_srv = this->create_service<std_srvs::srv::Trigger>("/provider_depth/tare", std::bind(&DepthProvider::tare, this, _1, _2));
+        _tareSrv = this->create_service<std_srvs::srv::Trigger>("/provider_depth/tare",
+                                                                std::bind(&DepthProvider::tare, this, _1, _2));
     }
 
     DepthProvider::~DepthProvider()
     {
-        _send_stop_thread = true;
-        _read_stop_thread = true;
+        _sendStopThread = true;
+        _readStopThread = true;
     }
 
     bool DepthProvider::OpenPort()
     {
-        bool res = _serialConnection.OpenPort();
+        bool res = this->_serialConnection.OpenPort();
         if (res)
         {
             _serialConnection.Flush();
@@ -40,80 +41,82 @@ namespace depth_provider
     void DepthProvider::readSerialDevice()
     {
         char buffer[BUFFER_SIZE];
-	std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        while (!_read_stop_thread)
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        while (!_readStopThread)
         {
             do
-            {   
-                _serialConnection.ReadOnce((uint8_t*)buffer,0);
+            {
+                _serialConnection.ReadOnce((uint8_t *)buffer, 0);
             } while (buffer[0] != '$');
 
-            int i;
+            int index;
 
-            for (i = 1; buffer[i - 1] != '\n' && i < BUFFER_SIZE; i++)
+            for (index = 1; buffer[index - 1] != '\n' && index < BUFFER_SIZE; index++)
             {
-                _serialConnection.ReadOnce((uint8_t *)buffer, i);
+                _serialConnection.ReadOnce((uint8_t *)buffer, index);
             }
 
-            if (i >= BUFFER_SIZE)
+            if (index >= BUFFER_SIZE)
             {
                 continue;
             }
 
-            buffer[i] = 0;
+            buffer[index] = 0;
 
-            if(!strncmp(&buffer[1], ID1, 5)) // Add checksum verification
+            if (strncmp(&buffer[1], ID1, ID_SIZE) == 0)  // Add checksum verification
             {
-                id1_string.push_back((std::string)buffer);
+                _id1String.push_back((std::string)buffer);
             }
 
-        } // end while
-    }     // end read
+        }  // end while
+    }      // end read
 
     void DepthProvider::sendId1Register()
     {
-        while (!_send_stop_thread)
+        while (!_sendStopThread)
         {
             std::string tmp = "";
 
-            while(!id1_string.empty()){
+            while (!_id1String.empty())
+            {
                 try
                 {
-                    std::stringstream ss(id1_string.get_n_pop_front());
+                    std::stringstream ss(_id1String.get_n_pop_front());
 
-                    std::getline(ss, tmp, ','); // Get the header of the message
+                    std::getline(ss, tmp, ',');  // Get the header of the message
 
-                    std::getline(ss, tmp, ','); // Get the depth
-                    depth_.data = stof(tmp);
-                    depthPublisher_->publish(depth_);
+                    std::getline(ss, tmp, ',');  // Get the depth
+                    _depth.data = stof(tmp);
+                    _depthPublisher->publish(_depth);
 
-                    std::getline(ss, tmp, ','); // skip M
+                    std::getline(ss, tmp, ',');  // skip M
 
-                    std::getline(ss, tmp, ','); // Get the pressure
-                    press_.data = stof(tmp);
-                    pressPublisher_->publish(press_);
+                    std::getline(ss, tmp, ',');  // Get the pressure
+                    _press.data = stof(tmp);
+                    _pressPublisher->publish(_press);
 
-                    std::getline(ss, tmp, ','); // skip B
-                    
-                    std::getline(ss, tmp, ','); // Get the temperature
-                    temp_.data = stof(tmp);
-                    tempPublisher_->publish(temp_);
-                    
+                    std::getline(ss, tmp, ',');  // skip B
+
+                    std::getline(ss, tmp, ',');  // Get the temperature
+                    _temp.data = stof(tmp);
+                    _tempPublisher->publish(_temp);
                 }
-                catch(...)
+                catch (...)
                 {
-                    BOOST_LOG_TRIVIAL(info)<<"Depth sensor : Bad packet error";
+                    BOOST_LOG_TRIVIAL(info) << "Depth sensor : Bad packet error";
                 }
-            }            
+            }
         }
     }
 
-    void DepthProvider::tare(const std::shared_ptr<std_srvs::srv::Trigger::Request> request, std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+    void DepthProvider::tare(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                             std::shared_ptr<std_srvs::srv::Trigger::Response> response)
     {
+        (void)request;
         _serialConnection.Transmit("#tare\n");
         std::this_thread::sleep_for(0.1s);
-        response->success=true;
-        response->message= "Depth Sensor tared";
-        BOOST_LOG_TRIVIAL(info)<<"Depth Sensor tare finished";
+        response->success = true;
+        response->message = "Depth Sensor tared";
+        BOOST_LOG_TRIVIAL(info) << "Depth Sensor tare finished";
     }
-} // end namespace
+}  // namespace depth_port_manager

--- a/src/DepthProvider.cpp
+++ b/src/DepthProvider.cpp
@@ -48,7 +48,7 @@ namespace depth_port_manager
         {
             if (_device.ReadDataCheck(
                     [&](uint8_t* pData, int offset) -> ssize_t { return _connection.ReadOnce(pData, offset); }, buffer,
-                    BUFFER_SIZE))
+                    BUFFER_SIZE) > 0)
             {
                 _id1String.push_back((std::string)buffer);
             }

--- a/src/DepthProvider.cpp
+++ b/src/DepthProvider.cpp
@@ -9,7 +9,7 @@ using namespace std::chrono_literals;
 
 namespace depth_port_manager
 {
-    DepthProvider::DepthProvider() : Node("depth_provider"), _serialConnection("/dev/DEPTH", B115200, true)
+    DepthProvider::DepthProvider(IDepthDevice& device, sonia_common_cpp::SerialConn& conn) : Node("depth_provider"), _device(device), _connection(conn)
     {
         _depthPublisher = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/depth", 100);
         _pressPublisher = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/press", 100);
@@ -30,10 +30,11 @@ namespace depth_port_manager
 
     bool DepthProvider::OpenPort()
     {
-        bool res = this->_serialConnection.OpenPort();
+        // TODO: lets see how this will work when the super class is created for connections.
+        bool res = this->_connection.OpenPort();
         if (res)
         {
-            _serialConnection.Flush();
+            _connection.Flush();
         }
         return res;
     }
@@ -44,30 +45,14 @@ namespace depth_port_manager
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         while (!_readStopThread)
         {
-            do
-            {
-                _serialConnection.ReadOnce((uint8_t *)buffer, 0);
-            } while (buffer[0] != '$');
-
-            int index;
-
-            for (index = 1; buffer[index - 1] != '\n' && index < BUFFER_SIZE; index++)
-            {
-                _serialConnection.ReadOnce((uint8_t *)buffer, index);
-            }
-
-            if (index >= BUFFER_SIZE)
-            {
-                continue;
-            }
-
-            buffer[index] = 0;
-
-            if (strncmp(&buffer[1], ID1, ID_SIZE) == 0)  // Add checksum verification
+            if (_device.ReadDataCheck(
+                [&](uint8_t *pData, int offset)->ssize_t {
+                    return _connection.ReadOnce(pData, offset);
+                },
+                buffer, BUFFER_SIZE))
             {
                 _id1String.push_back((std::string)buffer);
             }
-
         }  // end while
     }      // end read
 
@@ -79,32 +64,18 @@ namespace depth_port_manager
 
             while (!_id1String.empty())
             {
-                try
-                {
-                    std::stringstream ss(_id1String.get_n_pop_front());
+                DepthData data = _device.ParseData(_id1String.get_n_pop_front());
 
-                    std::getline(ss, tmp, ',');  // Get the header of the message
+                std_msgs::msg::Float32 publishData;
 
-                    std::getline(ss, tmp, ',');  // Get the depth
-                    _depth.data = stof(tmp);
-                    _depthPublisher->publish(_depth);
+                publishData.data = data.depth;
+                _depthPublisher->publish(publishData);
 
-                    std::getline(ss, tmp, ',');  // skip M
+                publishData.data = data.temp;
+                _tempPublisher->publish(publishData);
 
-                    std::getline(ss, tmp, ',');  // Get the pressure
-                    _press.data = stof(tmp);
-                    _pressPublisher->publish(_press);
-
-                    std::getline(ss, tmp, ',');  // skip B
-
-                    std::getline(ss, tmp, ',');  // Get the temperature
-                    _temp.data = stof(tmp);
-                    _tempPublisher->publish(_temp);
-                }
-                catch (...)
-                {
-                    BOOST_LOG_TRIVIAL(info) << "Depth sensor : Bad packet error";
-                }
+                publishData.data = data.press;
+                _pressPublisher->publish(publishData);
             }
         }
     }
@@ -113,8 +84,11 @@ namespace depth_port_manager
                              std::shared_ptr<std_srvs::srv::Trigger::Response> response)
     {
         (void)request;
-        _serialConnection.Transmit("#tare\n");
-        std::this_thread::sleep_for(0.1s);
+        _device.Tare(
+            [&](std::string data) -> ssize_t {
+                return _connection.Transmit(data);
+            }
+        );
         response->success = true;
         response->message = "Depth Sensor tared";
         BOOST_LOG_TRIVIAL(info) << "Depth Sensor tare finished";

--- a/src/DepthProvider.cpp
+++ b/src/DepthProvider.cpp
@@ -9,7 +9,8 @@ using namespace std::chrono_literals;
 
 namespace depth_port_manager
 {
-    DepthProvider::DepthProvider(IDepthDevice& device, sonia_common_cpp::SerialConn& conn) : Node("depth_provider"), _device(device), _connection(conn)
+    DepthProvider::DepthProvider(IDepthDevice& device, sonia_common_cpp::SerialConn& conn)
+        : Node("depth_provider"), _device(device), _connection(conn)
     {
         _depthPublisher = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/depth", 100);
         _pressPublisher = this->create_publisher<std_msgs::msg::Float32>("/provider_depth/press", 100);
@@ -46,10 +47,8 @@ namespace depth_port_manager
         while (!_readStopThread)
         {
             if (_device.ReadDataCheck(
-                [&](uint8_t *pData, int offset)->ssize_t {
-                    return _connection.ReadOnce(pData, offset);
-                },
-                buffer, BUFFER_SIZE))
+                    [&](uint8_t* pData, int offset) -> ssize_t { return _connection.ReadOnce(pData, offset); }, buffer,
+                    BUFFER_SIZE))
             {
                 _id1String.push_back((std::string)buffer);
             }
@@ -84,11 +83,7 @@ namespace depth_port_manager
                              std::shared_ptr<std_srvs::srv::Trigger::Response> response)
     {
         (void)request;
-        _device.Tare(
-            [&](std::string data) -> ssize_t {
-                return _connection.Transmit(data);
-            }
-        );
+        _device.Tare([&](std::string data) -> ssize_t { return _connection.Transmit(data); });
         response->success = true;
         response->message = "Depth Sensor tared";
         BOOST_LOG_TRIVIAL(info) << "Depth Sensor tare finished";

--- a/src/DepthProvider.cpp
+++ b/src/DepthProvider.cpp
@@ -29,17 +29,6 @@ namespace depth_port_manager
         _readStopThread = true;
     }
 
-    bool DepthProvider::OpenPort()
-    {
-        // TODO: lets see how this will work when the super class is created for connections.
-        bool res = this->_connection.OpenPort();
-        if (res)
-        {
-            _connection.Flush();
-        }
-        return res;
-    }
-
     void DepthProvider::readSerialDevice()
     {
         char buffer[BUFFER_SIZE];

--- a/src/ImpactSubsea.cpp
+++ b/src/ImpactSubsea.cpp
@@ -10,12 +10,10 @@ namespace depth_port_manager
 {
     const std::string ImpactSubsea::ID1 = "ISDPT";
 
-    bool ImpactSubsea::ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize)
+    int ImpactSubsea::ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize)
     {
-        do
-        {
-            readFunc((uint8_t *)buffer, 0);
-        } while (buffer[0] != '$');
+        readFunc((uint8_t *)buffer, 0);
+        if (buffer[0] != '$') {return 0;};
         int index;
 
         for (index = 1; buffer[index - 1] != '\n' && index < bufferSize; index++)
@@ -25,16 +23,16 @@ namespace depth_port_manager
 
         if (index >= bufferSize)
         {
-            return false;
+            return -1;
         }
 
         buffer[index] = 0;
 
         if (strncmp(&buffer[1], ImpactSubsea::ID1.c_str(), ImpactSubsea::ID_SIZE) == 0)  // Add checksum verification
         {
-            return true;
+            return index;
         }
-        return false;
+        return -2;
     }
 
     DepthData ImpactSubsea::ParseData(std::string data)

--- a/src/ImpactSubsea.cpp
+++ b/src/ImpactSubsea.cpp
@@ -1,0 +1,70 @@
+#include "depth_port_manager/ImpactSubsea.hpp"
+#include <cstring>
+#include <sstream>
+#include <boost/log/trivial.hpp>
+#include <thread>
+using namespace std::chrono_literals;
+
+namespace depth_port_manager
+{
+    const std::string ImpactSubsea::ID1 = "ISDPT";
+
+    bool ImpactSubsea::ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize)
+    {
+        do
+        {
+            readFunc((uint8_t *)buffer, 0);
+        } while (buffer[0] != '$');
+        int index;
+
+        for (index = 1; buffer[index - 1] != '\n' && index < bufferSize; index++)
+        {
+            readFunc((uint8_t *)buffer, index);
+        }
+
+        if (index >= bufferSize)
+        {
+            return false;
+        }
+
+        buffer[index] = 0;
+
+        if (strncmp(&buffer[1], ImpactSubsea::ID1.c_str(), ImpactSubsea::ID_SIZE) == 0)  // Add checksum verification
+        {
+            return true;
+        }
+        return false;
+    }
+
+    DepthData ImpactSubsea::ParseData(std::string data) {
+        DepthData returnVal;
+        std::string tmp = "";
+        try
+        {
+            std::stringstream ss(data);
+
+            std::getline(ss, tmp, ',');  // Get the header of the message
+            std::getline(ss, tmp, ',');  // Get the depth
+            returnVal.depth = stof(tmp);
+
+            std::getline(ss, tmp, ',');  // skip M
+            std::getline(ss, tmp, ',');  // Get the pressure
+            returnVal.press = stof(tmp);
+
+            std::getline(ss, tmp, ',');  // skip B
+            std::getline(ss, tmp, ',');  // Get the temperature
+            returnVal.temp = stof(tmp);
+        }
+        catch (...)
+        {
+            BOOST_LOG_TRIVIAL(info) << "Depth sensor : Bad packet error";
+        }
+        
+        return returnVal;
+    }
+
+    void ImpactSubsea::Tare(std::function<ssize_t(std::string)> writeFunc) {
+        writeFunc("#tare\n");
+        std::this_thread::sleep_for(0.1s);
+    }
+}  // namespace depth_port_manager

--- a/src/ImpactSubsea.cpp
+++ b/src/ImpactSubsea.cpp
@@ -13,7 +13,10 @@ namespace depth_port_manager
     int ImpactSubsea::ReadDataCheck(std::function<ssize_t(uint8_t *, int)> readFunc, char buffer[], int bufferSize)
     {
         readFunc((uint8_t *)buffer, 0);
-        if (buffer[0] != '$') {return 0;};
+        if (buffer[0] != '$')
+        {
+            return 0;
+        };
         int index;
 
         for (index = 1; buffer[index - 1] != '\n' && index < bufferSize; index++)

--- a/src/ImpactSubsea.cpp
+++ b/src/ImpactSubsea.cpp
@@ -1,7 +1,8 @@
 #include "depth_port_manager/ImpactSubsea.hpp"
+
+#include <boost/log/trivial.hpp>
 #include <cstring>
 #include <sstream>
-#include <boost/log/trivial.hpp>
 #include <thread>
 using namespace std::chrono_literals;
 
@@ -36,7 +37,8 @@ namespace depth_port_manager
         return false;
     }
 
-    DepthData ImpactSubsea::ParseData(std::string data) {
+    DepthData ImpactSubsea::ParseData(std::string data)
+    {
         DepthData returnVal;
         std::string tmp = "";
         try
@@ -59,11 +61,12 @@ namespace depth_port_manager
         {
             BOOST_LOG_TRIVIAL(info) << "Depth sensor : Bad packet error";
         }
-        
+
         return returnVal;
     }
 
-    void ImpactSubsea::Tare(std::function<ssize_t(std::string)> writeFunc) {
+    void ImpactSubsea::Tare(std::function<ssize_t(std::string)> writeFunc)
+    {
         writeFunc("#tare\n");
         std::this_thread::sleep_for(0.1s);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ int main(int argc, char *argv[])
     rclcpp::init(argc, argv);
     // Device and connection defined by env var.
     sonia_common_cpp::SerialConn conn("/dev/DEPTH", B115200, true);
-    
+
     if (!conn.OpenPort())
     {
         RCLCPP_FATAL(rclcpp::get_logger("depth_port_manager"), "Could not open port...");
@@ -17,10 +17,10 @@ int main(int argc, char *argv[])
 
     depth_port_manager::ImpactSubsea device;
     auto depth = std::make_shared<depth_port_manager::DepthProvider>(device, conn);
-    
+
     rclcpp::spin(depth);
-    
+
     rclcpp::shutdown();
-    
+
     return EXIT_SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,15 +1,19 @@
 #include <stdlib.h>
 
 #include "depth_port_manager/DepthProvider.hpp"
+#include "depth_port_manager/ImpactSubsea.hpp"
 
 int main(int argc, char *argv[])
 {
     rclcpp::init(argc, argv);
-    auto depth = std::make_shared<depth_port_manager::DepthProvider>();
+    // Device and connection defined by env var.
+    depth_port_manager::ImpactSubsea device;
+    sonia_common_cpp::SerialConn conn("/dev/DEPTH", B115200, true);
+    auto depth = std::make_shared<depth_port_manager::DepthProvider>(device, conn);
 
     if (!depth->OpenPort())
     {
-        std::cout << "Could not open port..." << std::endl;
+        RCLCPP_FATAL(rclcpp::get_logger("depth_port_manager"), "Could not open port...");
         return EXIT_FAILURE;
     }
     rclcpp::spin(depth);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,16 +7,20 @@ int main(int argc, char *argv[])
 {
     rclcpp::init(argc, argv);
     // Device and connection defined by env var.
-    depth_port_manager::ImpactSubsea device;
     sonia_common_cpp::SerialConn conn("/dev/DEPTH", B115200, true);
-    auto depth = std::make_shared<depth_port_manager::DepthProvider>(device, conn);
-
-    if (!depth->OpenPort())
+    
+    if (!conn.OpenPort())
     {
         RCLCPP_FATAL(rclcpp::get_logger("depth_port_manager"), "Could not open port...");
         return EXIT_FAILURE;
     }
+
+    depth_port_manager::ImpactSubsea device;
+    auto depth = std::make_shared<depth_port_manager::DepthProvider>(device, conn);
+    
     rclcpp::spin(depth);
+    
     rclcpp::shutdown();
+    
     return EXIT_SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,15 +1,14 @@
-#include "depth_port_manager/DepthProvider.hpp"
 #include <stdlib.h>
-#include <iostream>
-#include <chrono>
+
+#include "depth_port_manager/DepthProvider.hpp"
 
 int main(int argc, char *argv[])
 {
     rclcpp::init(argc, argv);
-    auto depth= std::make_shared<depth_provider::DepthProvider>();
-    
+    auto depth = std::make_shared<depth_port_manager::DepthProvider>();
+
     if (!depth->OpenPort())
-    {   
+    {
         std::cout << "Could not open port..." << std::endl;
         return EXIT_FAILURE;
     }

--- a/test/test_ImpactSubsea.cpp
+++ b/test/test_ImpactSubsea.cpp
@@ -1,62 +1,59 @@
 #include <gtest/gtest.h>
+
 #include <depth_port_manager/ImpactSubsea.hpp>
 
 
 TEST(ReadDataCheck, BadStartChar)
 {
-    // CharGenerator gen({'6', 'a', '5','\n'});
-    char data[] = {'6', 'a', '5','\n'};
+    char data[] = {'6', 'a', '5', '\n'};
     depth_port_manager::ImpactSubsea device;
     char buffer[10];
     ASSERT_EQ(device.ReadDataCheck(
-        [&](uint8_t* pData, int offset) {
-            pData[offset]=data[offset];
-            return 1;
-        },
-        buffer,
-        10
-    ), 0);
+                  [&](uint8_t* pData, int offset) {
+                      pData[offset] = data[offset];
+                      return 1;
+                  },
+                  buffer, 10),
+              0);
 }
 
 TEST(ReadDataCheck, NoEndBuffTooSmall)
 {
     char data1[] = {'$', '1', '2', '3', '4', '5'};
-    
+
     depth_port_manager::ImpactSubsea device;
     char buffer[10];
     ASSERT_EQ(device.ReadDataCheck(
-        [&](uint8_t* pData, int offset) {
-            pData[offset]=data1[offset];
-            return 1;
-        },
-        buffer,
-        10
-    ), -1);
+                  [&](uint8_t* pData, int offset) {
+                      pData[offset] = data1[offset];
+                      return 1;
+                  },
+                  buffer, 10),
+              -1);
     char data2[] = {'$', '1', '2', '3', '4', '5', '0', '0', '0', '0', '0', '0', '\n'};
     ASSERT_EQ(device.ReadDataCheck(
-        [&](uint8_t* pData, int offset) {
-            pData[offset]=data2[offset];
-            return 1;
-        },
-        buffer,
-        10
-    ), -1);
+                  [&](uint8_t* pData, int offset) {
+                      pData[offset] = data2[offset];
+                      return 1;
+                  },
+                  buffer, 10),
+              -1);
 }
 
 TEST(ReadDataCheck, BadID)
 {
     std::stringstream data;
-    data << "$" << "3456\n";
+    data << "$"
+         << "3456\n";
     depth_port_manager::ImpactSubsea device;
     char buffer[10];
     ASSERT_EQ(device.ReadDataCheck(
-        [&](uint8_t* pData, int offset) {
-            pData[offset]=data.str().c_str()[offset];
-            return 1;
-        },
-        buffer,
-        10
-    ), -2);
+                  [&](uint8_t* pData, int offset) {
+                      pData[offset] = data.str().c_str()[offset];
+                      return 1;
+                  },
+                  buffer, 10),
+              -2);
 }
 
 TEST(ReadDataCheck, GoodMessage)
@@ -68,41 +65,35 @@ TEST(ReadDataCheck, GoodMessage)
     depth_port_manager::ImpactSubsea device;
     char buffer[15];
     ASSERT_EQ(device.ReadDataCheck(
-        [&](uint8_t* pData, int offset) {
-            pData[offset]=data.str().c_str()[offset];
-            return 1;
-        },
-        buffer,
-        15
-    ), data.str().size());
+                  [&](uint8_t* pData, int offset) {
+                      pData[offset] = data.str().c_str()[offset];
+                      return 1;
+                  },
+                  buffer, 15),
+              data.str().size());
 }
 
-TEST(ParseData, parseID123) {
+TEST(ParseData, parseID123)
+{
     // $ISDPT,dddd.ddd,M,ppp.pppp,B,tt.tt,C*xx<CR><LF>
     depth_port_manager::ImpactSubsea device;
     depth_port_manager::DepthData output;
     output.depth = 123.456;
     output.press = 789.0123;
     output.temp = 23.45;
-    char buffer[41] = {
-        '$', 'I', 'S', 'D', 'P', 'T', ',', 
-        '0', '1', '2', '3', '.', '4', '5', '6', ',', 
-        'M', ',', 
-        '7', '8', '9', '.', '0', '1', '2', '3', ',', 
-        'B', ',', 
-        '2', '3', '.', '4', '5', ',', 
-        'C', '*', 'x', 'x', '\n', '\0'};
+    char buffer[41] = {'$', 'I', 'S', 'D', 'P', 'T', ',', '0', '1', '2', '3', '.',  '4', '5',
+                       '6', ',', 'M', ',', '7', '8', '9', '.', '0', '1', '2', '3',  ',', 'B',
+                       ',', '2', '3', '.', '4', '5', ',', 'C', '*', 'x', 'x', '\n', '\0'};
     ASSERT_EQ(device.ParseData(buffer), output);
 };
 
-TEST(Tare, expectedTareCmd) {
+TEST(Tare, expectedTareCmd)
+{
     depth_port_manager::ImpactSubsea device;
     std::string output;
-    device.Tare(
-        [&](std::string val)->ssize_t {
-            output = val;
-            return 0;
-        }
-    );
+    device.Tare([&](std::string val) -> ssize_t {
+        output = val;
+        return 0;
+    });
     ASSERT_EQ(output, "#tare\n");
 }

--- a/test/test_ImpactSubsea.cpp
+++ b/test/test_ImpactSubsea.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+#include <depth_port_manager/ImpactSubsea.hpp>
+
+
+TEST(ReadDataCheck, BadStartChar)
+{
+    // CharGenerator gen({'6', 'a', '5','\n'});
+    char data[] = {'6', 'a', '5','\n'};
+    depth_port_manager::ImpactSubsea device;
+    char buffer[10];
+    ASSERT_EQ(device.ReadDataCheck(
+        [&](uint8_t* pData, int offset) {
+            pData[offset]=data[offset];
+            return 1;
+        },
+        buffer,
+        10
+    ), 0);
+}
+
+TEST(ReadDataCheck, NoEndBuffTooSmall)
+{
+    char data1[] = {'$', '1', '2', '3', '4', '5'};
+    
+    depth_port_manager::ImpactSubsea device;
+    char buffer[10];
+    ASSERT_EQ(device.ReadDataCheck(
+        [&](uint8_t* pData, int offset) {
+            pData[offset]=data1[offset];
+            return 1;
+        },
+        buffer,
+        10
+    ), -1);
+    char data2[] = {'$', '1', '2', '3', '4', '5', '0', '0', '0', '0', '0', '0', '\n'};
+    ASSERT_EQ(device.ReadDataCheck(
+        [&](uint8_t* pData, int offset) {
+            pData[offset]=data2[offset];
+            return 1;
+        },
+        buffer,
+        10
+    ), -1);
+}
+
+TEST(ReadDataCheck, BadID)
+{
+    std::stringstream data;
+    data << "$" << "3456\n";
+    depth_port_manager::ImpactSubsea device;
+    char buffer[10];
+    ASSERT_EQ(device.ReadDataCheck(
+        [&](uint8_t* pData, int offset) {
+            pData[offset]=data.str().c_str()[offset];
+            return 1;
+        },
+        buffer,
+        10
+    ), -2);
+}
+
+TEST(ReadDataCheck, GoodMessage)
+{
+    std::stringstream data;
+    data << "$";
+    data << depth_port_manager::ImpactSubsea::ID1;
+    data << "3456\n";
+    depth_port_manager::ImpactSubsea device;
+    char buffer[15];
+    ASSERT_EQ(device.ReadDataCheck(
+        [&](uint8_t* pData, int offset) {
+            pData[offset]=data.str().c_str()[offset];
+            return 1;
+        },
+        buffer,
+        15
+    ), data.str().size());
+}
+
+TEST(ParseData, parseID123) {
+    // $ISDPT,dddd.ddd,M,ppp.pppp,B,tt.tt,C*xx<CR><LF>
+    depth_port_manager::ImpactSubsea device;
+    depth_port_manager::DepthData output;
+    output.depth = 123.456;
+    output.press = 789.0123;
+    output.temp = 23.45;
+    char buffer[41] = {
+        '$', 'I', 'S', 'D', 'P', 'T', ',', 
+        '0', '1', '2', '3', '.', '4', '5', '6', ',', 
+        'M', ',', 
+        '7', '8', '9', '.', '0', '1', '2', '3', ',', 
+        'B', ',', 
+        '2', '3', '.', '4', '5', ',', 
+        'C', '*', 'x', 'x', '\n', '\0'};
+    ASSERT_EQ(device.ParseData(buffer), output);
+};
+
+TEST(Tare, expectedTareCmd) {
+    depth_port_manager::ImpactSubsea device;
+    std::string output;
+    device.Tare(
+        [&](std::string val)->ssize_t {
+            output = val;
+            return 0;
+        }
+    );
+    ASSERT_EQ(output, "#tare\n");
+}


### PR DESCRIPTION
# Clean Up & split Node and logic
Ran clang-tidy and clang-format. Also seperated Device logic from the ROS Node.

## Added Files
- include/depth_port_manager/IDepthDevice.hpp:
    - Interface that defines what functions are needed for a Depth Device.
- include/depth_port_manager/ImpactSubsea.hpp:
- src/ImpactSubsea.cpp"
    - Depth Device implementation for the Impact Subsea Depth Sensor.
- test/test_ImpactSubsea.cpp:
    - Added Test to make sure the communication works.

## Modified Files
- .clang-tidy:
    - Updated checks for quality.
- CMakeLists.txt:
    - Added Tests.
- include/depth_port_manager/DepthProvider.hpp:
- src/DepthProvider.cpp:
    - Removed all device logic from provider. It is now just a ROS node.
- src/main.cpp:
    - Dedicated implementation of device and connection.
    - Connection opens port, not Node.